### PR TITLE
Rename "typeIdentifier" to just "type"

### DIFF
--- a/peerbridge-ios/Messages/Models/ContentMessage.swift
+++ b/peerbridge-ios/Messages/Models/ContentMessage.swift
@@ -3,11 +3,11 @@ import Foundation
 
 
 struct ContentMessage: Message {
-    let typeIdentifier: String
+    let type: String
     let content: String
     
     init(content: String) {
-        self.typeIdentifier = "content"
+        self.type = "content"
         self.content = content
     }
     

--- a/peerbridge-ios/Messages/Models/Message.swift
+++ b/peerbridge-ios/Messages/Models/Message.swift
@@ -4,7 +4,7 @@ import CryptoKit
 
 public protocol Message: Codable {
     /// Messages must denote a type identifier string to avoid decoding ambiguity
-    var typeIdentifier: String { get }
+    var type: String { get }
     
     /// Messages must give a short description for the chat view preview
     var shortDescription: String { get }

--- a/peerbridge-ios/Messages/Models/TokenMessage.swift
+++ b/peerbridge-ios/Messages/Models/TokenMessage.swift
@@ -3,11 +3,11 @@ import Foundation
 
 
 struct TokenMessage: Message {
-    let typeIdentifier: String
+    let type: String
     let token: NotificationToken
     
     init(token: NotificationToken) {
-        self.typeIdentifier = "token"
+        self.type = "token"
         self.token = token
     }
     


### PR DESCRIPTION
This is simply a stylistic choice, but it allows me on the Android Side to use the `@SerialName` annotation from [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization/).

Given we have the following
```kotlin
@Serializable
sealed class Message {
    abstract val teaser: String
}

@Serializable
@SerialName("content")
data class ContentMessage(val content: String) : Message() {
    override val teaser: String
        get() = content
}
```

The resulting serialization will be
```kotlin
fun main() {
    val msg: Message = ContentMessage("Hello")
    println(json.encodeToString(msg))
   // {"type":"content","content":"Hello"}
}
```

Which is simply syntactic sugar instead of having something like
```kotlin
@Serializable
sealed class Message {
    abstract val typeIdentifier: String
    abstract val teaser: String
}

@Serializable
data class ContentMessage(val content: String) : Message() {
    override val typeIdentifier: String
        get() = "content"
    override val teaser: String
        get() = content
}
```

If it does not make a big difference for you, then I would be happy to change the name of `typeIdentifier` to just `type`. 
See [here](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/polymorphism.md#concrete-properties-in-a-base-class) for reference.